### PR TITLE
Wait for the map to be initialized

### DIFF
--- a/src/MapkitProvider.tsx
+++ b/src/MapkitProvider.tsx
@@ -47,7 +47,12 @@ export const MapkitProvider: React.FC<ProviderProps> = ({
             }
           },
         })
-        setContext({ mapkit, isInProvider: true })
+                
+        mapkit.addEventListener("configuration-change", (event)=> {
+            if (event.status === 'Initialized') {
+              SetContext({ mapkit, isInProvider: true });
+            }
+        });
       })
     }
   }, [existingContext.isInProvider, tokenOrCallback])


### PR DESCRIPTION
Map will be available before it is initialized resulting in unexpected behaviors. For example setRegionAnimated provides a slightly different result, but adding a 500ms delay it draws as expected (or adding this push also fixes it).

Wait for the map to be initialized before providing it to the context ensures the map acts as expected.