### PR TITLE
Relax peer dependency requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "dist"
   ],
   "peerDependencies": {
-    "react": "16.8.x",
-    "react-dom": "16.8.x"
+    "react": "16.x",
+    "react-dom": "16.x"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Hi @chrisdrackett. I'm not certain that this is safe, if this package does specifically require _only_ the .8 revision of React/DOM 16.x, then do go ahead and reject this PR, but my guess would be that any revision in version 16 will work.

This change should prevent incorrect peer dependency warnings from yarn/npm on up-to-date projects.