### PR TITLE
add Marker useEffect cleanup

### DIFF
--- a/src/Marker.tsx
+++ b/src/Marker.tsx
@@ -29,6 +29,8 @@ export const Marker: React.FC<MarkerProps> = ({
       )
 
       map.addAnnotation(marker.current)
+      
+      return () => marker.current && map && map.removeAnnotation(marker.current)
     }
   }, [mapkit, map])
 


### PR DESCRIPTION
In writing a basic searchable map, I noticed removing Markers didn't work. This fixes that

Example:
```tsx
const App = () => {
  const {
    mapkit,
    map,
    mapProps,
  } = useMap();

  const [searchInput, setSearchInput] = useState('coffee shop');
  const [searchResults, setSearchResults] = useState([] as mapkit.MarkerAnnotation[]);

  const clearSearchResults = () => {
    setSearchResults([]);
  }

  const searchPlaces = () => {
    clearSearchResults();

    const search = new mapkit.Search({ region: map.region });
    search.search(searchInput, (error, data) => {
      if (error) {
        return;
      }

      const annotations = data.places.map((place: any) => {
        const annotation = new mapkit.MarkerAnnotation(place.coordinate);
        annotation.title = place.name;
        annotation.subtitle = place.formattedAddress;
        annotation.color = "#9B6134";
        return annotation;
      });

      setSearchResults(annotations);
    });
  }

  return (
    <>
      { /** @ts-ignore */ }
      <input type="text" name="search" value={searchInput} onChange={(e) => setSearchInput(e.target.value)} />
      <button onClick={searchPlaces}>search</button>
      <button onClick={clearSearchResults}>clear</button>
      <Map {...mapProps}>
        {
          searchResults.map(r => <Marker
            latitude={r.coordinate.latitude}
            longitude={r.coordinate.longitude}
            title={r.title}
          />)
        }
      </Map>
    </>
  );
}
```